### PR TITLE
Conversation saving into jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Please Note:
 
 3. Access the generated link in your browser to start using the Local Code Interpreter.
 
+4. Use the `-n` or `--notebook` option to save the conversation in a notebook.
+   By default the notebook is saved in the working directory, but you can add a path to save it elsewhere.
+   ```shell
+   python web_ui.py -n <path_to_notebook>
+   ```
+   [notebook_gif_demo](example_img/save_to_notebook_demo.gif)
+
 ## Example
 
 Imagine uploading a data file and requesting the model to perform linear regression and visualize the data. See how Local Code Interpreter provides a seamless experience:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ Please Note:
    ```shell
    python web_ui.py -n <path_to_notebook>
    ```
-   [notebook_gif_demo](example_img/save_to_notebook_demo.gif)
 
 ## Example
 
@@ -123,5 +122,7 @@ Imagine uploading a data file and requesting the model to perform linear regress
    ![Example 5](example_img/5.jpg)
    ![Example 6](example_img/6.jpg)
 
+6. Use `--notebook` comand to save the conversation:
+   ![notebook_gif_demo](example_img/save_to_notebook_demo.gif)
 
 

--- a/requirements_full.txt
+++ b/requirements_full.txt
@@ -14,3 +14,4 @@ PyPDF2
 pdfminer.six
 sympy
 scikit-learn
+ansi2html

--- a/src/bot_backend.py
+++ b/src/bot_backend.py
@@ -6,7 +6,7 @@ import shutil
 from jupyter_backend import *
 from typing import *
 
-from notebook_serializer import append_markdown, append_code_cell
+from notebook_serializer import add_markdown_to_notebook, add_code_cell_to_notebook
 
 functions = [
     {
@@ -160,7 +160,7 @@ class BotBackend(GPTResponseLog):
         self.conversation.append(
             {'role': self.assistant_role_name, 'content': self.content}
         )
-        append_markdown(self.content, title="Assistant")
+        add_markdown_to_notebook(self.content, title="Assistant")
 
     def add_text_message(self, user_text):
         self.conversation.append(
@@ -168,7 +168,7 @@ class BotBackend(GPTResponseLog):
         )
         self.revocable_files.clear()
         self.update_finish_reason(finish_reason='new_input')
-        append_markdown(user_text, title="User")
+        add_markdown_to_notebook(user_text, title="User")
 
         
 
@@ -195,11 +195,11 @@ class BotBackend(GPTResponseLog):
         # I assusme this is due to hallucinatory function calls.
         try: # Try to load json formatted code.
             code_cell_obj = json.loads(self.function_args_str)
-            append_code_cell(code_cell_obj['code'])
+            add_code_cell_to_notebook(code_cell_obj['code'])
         except Exception:
             # If json.loads raises an error, it is most likely that the self.function_args_str is not json formatted,
             # and that we can treat it as the actual code.
-            append_code_cell(self.function_args_str)
+            add_code_cell_to_notebook(self.function_args_str)
 
         self.conversation.append(
             {

--- a/src/bot_backend.py
+++ b/src/bot_backend.py
@@ -193,23 +193,8 @@ class BotBackend(GPTResponseLog):
         )
 
     def add_function_call_response_message(self, function_response: str, save_tokens=True):
-        # Add code cell to notebook
-        # The format of the generated code is not consistent, but it tends to be in either of the followings:
-        # -json {"code" : "<actual_code>"} format,
-        # -in json format but with \\n instead of actual line breaks
-        # -plain text
-        try:
-            # We assume that the generated code is in bad formated json.
-            # Replace occurences of '\\n' into '\n'
-            code_obj = json.loads(self.function_args_str.replace('\\n', '\n'))
-            print("succefully loaded code as json:", code_obj['code'])
-            add_code_cell_to_notebook(code_obj['code'])
-        except Exception as e:
-            print("json.loads raised an exception:", e)
-            print("Code:", self.function_args_str)
-            # If an exception was raised, it most likely means that the code is in plain text.
-            add_code_cell_to_notebook(self.function_args_str)
-        
+        add_code_cell_to_notebook(self.code_str)
+
         self.conversation.append(
             {
                 "role": self.assistant_role_name,

--- a/src/bot_backend.py
+++ b/src/bot_backend.py
@@ -63,6 +63,7 @@ class GPTResponseLog:
         self.content = ''
         self.function_name = None
         self.function_args_str = ''
+        self.code_str = ''
         self.display_code_block = ''
         self.finish_reason = 'stop'
         self.bot_history = None
@@ -75,6 +76,7 @@ class GPTResponseLog:
                       'content': '',
                       'function_name': None,
                       'function_args_str': '',
+                      'code_str': '',
                       'display_code_block': '',
                       'finish_reason': 'stop',
                       'bot_history': None}
@@ -98,6 +100,9 @@ class GPTResponseLog:
 
     def add_function_args_str(self, function_args_str: str):
         self.function_args_str += function_args_str
+
+    def update_code_str(self, code_str: str):
+        self.code_str = code_str
 
     def update_display_code_block(self, display_code_block):
         self.display_code_block = display_code_block

--- a/src/bot_backend.py
+++ b/src/bot_backend.py
@@ -5,8 +5,6 @@ import copy
 import shutil
 from jupyter_backend import *
 from typing import *
-# from functional import parse_json
-# from response_parser import get_code_str
 from notebook_serializer import add_markdown_to_notebook, add_code_cell_to_notebook
 
 functions = [

--- a/src/bot_backend.py
+++ b/src/bot_backend.py
@@ -5,7 +5,8 @@ import copy
 import shutil
 from jupyter_backend import *
 from typing import *
-
+# from functional import parse_json
+# from response_parser import get_code_str
 from notebook_serializer import add_markdown_to_notebook, add_code_cell_to_notebook
 
 functions = [
@@ -189,17 +190,16 @@ class BotBackend(GPTResponseLog):
         )
 
     def add_function_call_response_message(self, function_response: str, save_tokens=True):
-        # Add code to notebook cells.
-        # For some reason, the self.function_args_str is an object with a code key leading to the actual code string.
-        # example of json formatted string: '{"code": "<actual code>"}'
-        # I assusme this is due to hallucinatory function calls.
-        try: # Try to load json formatted code.
-            code_cell_obj = json.loads(self.function_args_str)
-            add_code_cell_to_notebook(code_cell_obj['code'])
-        except Exception:
-            # If json.loads raises an error, it is most likely that the self.function_args_str is not json formatted,
-            # and that we can treat it as the actual code.
-            add_code_cell_to_notebook(self.function_args_str)
+        print(self.function_args_str)
+        try:
+            from functional import parse_json
+            code_str = parse_json(self.function_args_str, True)
+            if code_str:
+                add_code_cell_to_notebook(code_str)
+        except Exception as e:
+            print(f"Caught exception while trying to add code to notebook: {e}")
+        # code_str = get_code_str(self)
+        # add_code_cell_to_notebook(code_str)
 
         self.conversation.append(
             {

--- a/src/functional.py
+++ b/src/functional.py
@@ -2,7 +2,7 @@ from bot_backend import *
 import base64
 import time
 
-from notebook_serializer import append_code_cell_error, append_image, append_code_cell_output
+from notebook_serializer import add_code_cell_error_to_notebook, add_image_to_notebook, add_code_cell_output_to_notebook
 
 def chat_completion(bot_backend: BotBackend):
     model_choice = bot_backend.gpt_model_choice
@@ -25,19 +25,19 @@ def add_function_response_to_bot_history(content_to_display, history, unique_id)
     for mark, out_str in content_to_display:
         if mark in ('stdout', 'execute_result_text', 'display_text'):
             text.append(out_str)
-            append_code_cell_output(out_str)
+            add_code_cell_output_to_notebook(out_str)
         elif mark in ('execute_result_png', 'execute_result_jpeg', 'display_png', 'display_jpeg'):
             if 'png' in mark:
                 images.append(('png', out_str))
-                append_image(out_str, 'image/png')
+                add_image_to_notebook(out_str, 'image/png')
             else:
-                append_image(out_str, 'image/jpeg')
+                add_image_to_notebook(out_str, 'image/jpeg')
                 images.append(('jpg', out_str))
         elif mark == 'error':
             # Set output type to error
             text.append(delete_color_control_char(out_str))
             error_occurred = True
-            append_code_cell_error(out_str)
+            add_code_cell_error_to_notebook(out_str)
     text = '\n'.join(text).strip('\n')
     if error_occurred:
         history.append([None, f'❌Terminal output:\n```shell\n\n{text}\n```'])

--- a/src/functional.py
+++ b/src/functional.py
@@ -2,7 +2,7 @@ from bot_backend import *
 import base64
 import time
 
-from notebook_serializer import notebbok_cells
+from notebook_serializer import append_code_cell_error, append_image, append_code_cell_output
 
 def chat_completion(bot_backend: BotBackend):
     model_choice = bot_backend.gpt_model_choice
@@ -22,29 +22,22 @@ def add_function_response_to_bot_history(content_to_display, history, unique_id)
     # terminal output
     error_occurred = False
 
-    # Add 'outputs' key-value pairs to the last notebook cell
-    notebbok_cells[-1]['outputs'] = []
-
     for mark, out_str in content_to_display:
-        # Foreach output of the cell, append new dict with content of the ouptput
-        notebbok_cells[-1]['outputs'].append({'content': out_str})
-
         if mark in ('stdout', 'execute_result_text', 'display_text'):
             text.append(out_str)
-            # Set output type to stdout
-            notebbok_cells[-1]['outputs'][-1]['type'] = 'stdout'
+            append_code_cell_output(out_str)
         elif mark in ('execute_result_png', 'execute_result_jpeg', 'display_png', 'display_jpeg'):
             if 'png' in mark:
                 images.append(('png', out_str))
-                notebbok_cells[-1]['outputs'][-1]['type'] = 'image/png'
+                append_image(out_str, 'image/png')
             else:
-                notebbok_cells[-1]['outputs'][-1]['type'] = 'image/jpeg'
+                append_image(out_str, 'image/jpeg')
                 images.append(('jpg', out_str))
         elif mark == 'error':
             # Set output type to error
             text.append(delete_color_control_char(out_str))
             error_occurred = True
-            notebbok_cells[-1]['outputs'][-1]['type'] = 'error'
+            append_code_cell_error(out_str)
     text = '\n'.join(text).strip('\n')
     if error_occurred:
         history.append([None, f'❌Terminal output:\n```shell\n\n{text}\n```'])

--- a/src/functional.py
+++ b/src/functional.py
@@ -1,7 +1,6 @@
 from bot_backend import *
 import base64
 import time
-
 from notebook_serializer import add_code_cell_error_to_notebook, add_image_to_notebook, add_code_cell_output_to_notebook
 
 def chat_completion(bot_backend: BotBackend):

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -1,9 +1,7 @@
 import nbformat
 from nbformat import v4 as nbf
 import ansi2html
-import sys
 import os
-import json
 import argparse
 
 # main code
@@ -29,18 +27,18 @@ def write_to_notebook():
         with open(notebook_path, 'w') as f:
             nbformat.write(nb, f)
 
-def append_code_cell(code):
+def add_code_cell_to_notebook(code):
     code_cell = nbf.new_code_cell(source=code)
     nb['cells'].append(code_cell)
     write_to_notebook()
 
-def append_code_cell_output(output):
+def add_code_cell_output_to_notebook(output):
     html_content = ansi_to_html(output)
     cell_output = nbf.new_output(output_type='display_data', data={'text/html': html_content})
     nb['cells'][-1]['outputs'].append(cell_output)
     write_to_notebook()
 
-def append_code_cell_error(error):
+def add_code_cell_error_to_notebook(error):
     nbf_error_output = nbf.new_output(
         output_type='error',
         ename='Error',
@@ -50,12 +48,12 @@ def append_code_cell_error(error):
     nb['cells'][-1]['outputs'].append(nbf_error_output)
     write_to_notebook()
 
-def append_image(image, mime_type):
+def add_image_to_notebook(image, mime_type):
     image_output = nbf.new_output(output_type='display_data', data={mime_type: image})
     nb['cells'][-1]['outputs'].append(image_output)
     write_to_notebook()
 
-def append_markdown(content, title=None):
+def add_markdown_to_notebook(content, title=None):
     if title:
         content = "##### " + title + ":\n" + content
     markdown_cell = nbf.new_markdown_cell(content)

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -8,8 +8,8 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument("-n", "--notebook", help="Path to the output notebook", default=None, type=str)
 args = parser.parse_args()
-if args.notebook_path:
-    notebook_path = os.path.join(os.getcwd(), args.notebook_path)
+if args.notebook:
+    notebook_path = os.path.join(os.getcwd(), args.notebook)
     base, ext = os.path.splitext(notebook_path)
     if ext.lower() != '.ipynb':
         notebook_path += '.ipynb'
@@ -23,7 +23,7 @@ def ansi_to_html(ansi_text):
     return html_text
 
 def write_to_notebook():
-    if args.notebook_path:
+    if args.notebook:
         with open(notebook_path, 'w') as f:
             nbformat.write(nb, f)
 

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -24,7 +24,7 @@ def ansi_to_html(ansi_text):
 
 def write_to_notebook():
     if args.notebook:
-        with open(notebook_path, 'w') as f:
+        with open(notebook_path, 'w', encoding='utf-8') as f:
             nbformat.write(nb, f)
 
 def add_code_cell_to_notebook(code):

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -1,0 +1,52 @@
+import nbformat
+from nbformat import v4 as nbf
+import ansi2html
+import sys
+import os
+import json
+
+# Get UNIQUE notebook path with argv and cwd
+
+
+# Global variable for code cells
+notebbok_cells = []
+
+def ansi_to_html(ansi_text):
+    converter = ansi2html.Ansi2HTMLConverter()
+    html_text = converter.convert(ansi_text)
+    return html_text
+
+def serialize_conv_into_notebook():
+
+    nb = nbf.new_notebook()
+    try:
+        for cell in notebbok_cells:
+            if cell['type'] == 'code':
+                code_cell = nbf.new_code_cell(source=cell['code'])
+                for output in cell['outputs']:
+                    if output['type'] == 'stdout':
+                        html_content = ansi_to_html(output['content'])
+                        code_cell['outputs'].append(nbf.new_output(output_type='display_data', data={'text/html': html_content}))
+                    elif output['type'] == 'error':
+                        # Convert ANSI to HTML and add as display_data instead of traceback
+                        html_content = ansi_to_html(output['content'])
+                        nbf_error_output = nbf.new_output(
+                            output_type='error',
+                            ename='Error',
+                            evalue='Error message',
+                            traceback=[output['content']]
+                        )
+                        code_cell['outputs'].append(nbf_error_output)
+                    elif 'image' in output['type']:
+                        code_cell['outputs'].append(nbf.new_output(output_type='display_data', data={output['type']: output['content']}))
+                nb['cells'].append(code_cell)
+            
+            if cell['type'] == 'markdown':
+                markdown_cell = nbf.new_markdown_cell(cell['markdown'])
+                nb['cells'].append(markdown_cell)
+    except Exception as e:
+        print(f"Caught error during conv serialization: '{e}'")
+
+    # Save the notebook
+    with open('output_notebook.ipynb', 'w') as f:
+        nbformat.write(nb, f)

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -9,44 +9,46 @@ import json
 
 
 # Global variable for code cells
-notebbok_cells = []
+nb = nbf.new_notebook()
 
 def ansi_to_html(ansi_text):
     converter = ansi2html.Ansi2HTMLConverter()
     html_text = converter.convert(ansi_text)
     return html_text
 
-def serialize_conv_into_notebook():
-
-    nb = nbf.new_notebook()
-    try:
-        for cell in notebbok_cells:
-            if cell['type'] == 'code':
-                code_cell = nbf.new_code_cell(source=cell['code'])
-                for output in cell['outputs']:
-                    if output['type'] == 'stdout':
-                        html_content = ansi_to_html(output['content'])
-                        code_cell['outputs'].append(nbf.new_output(output_type='display_data', data={'text/html': html_content}))
-                    elif output['type'] == 'error':
-                        # Convert ANSI to HTML and add as display_data instead of traceback
-                        html_content = ansi_to_html(output['content'])
-                        nbf_error_output = nbf.new_output(
-                            output_type='error',
-                            ename='Error',
-                            evalue='Error message',
-                            traceback=[output['content']]
-                        )
-                        code_cell['outputs'].append(nbf_error_output)
-                    elif 'image' in output['type']:
-                        code_cell['outputs'].append(nbf.new_output(output_type='display_data', data={output['type']: output['content']}))
-                nb['cells'].append(code_cell)
-            
-            if cell['type'] == 'markdown':
-                markdown_cell = nbf.new_markdown_cell(cell['markdown'])
-                nb['cells'].append(markdown_cell)
-    except Exception as e:
-        print(f"Caught error during conv serialization: '{e}'")
-
-    # Save the notebook
+def write_to_notebook():
     with open('output_notebook.ipynb', 'w') as f:
         nbformat.write(nb, f)
+
+def append_code_cell(code):
+    code_cell = nbf.new_code_cell(source=code)
+    nb['cells'].append(code_cell)
+    write_to_notebook()
+
+def append_code_cell_output(output):
+    html_content = ansi_to_html(output)
+    cell_output = nbf.new_output(output_type='display_data', data={'text/html': html_content})
+    nb['cells'][-1]['outputs'].append(cell_output)
+    write_to_notebook()
+
+def append_code_cell_error(error):
+    nbf_error_output = nbf.new_output(
+        output_type='error',
+        ename='Error',
+        evalue='Error message',
+        traceback=[error]
+    )
+    nb['cells'][-1]['outputs'].append(nbf_error_output)
+    write_to_notebook()
+
+def append_image(image, mime_type):
+    image_output = nbf.new_output(output_type='display_data', data={mime_type: image})
+    nb['cells'][-1]['outputs'].append(image_output)
+    write_to_notebook()
+
+def append_markdown(content, title=None):
+    if title:
+        content = "##### " + title + ":\n" + content
+    markdown_cell = nbf.new_markdown_cell(content)
+    nb['cells'].append(markdown_cell)
+    write_to_notebook()

--- a/src/notebook_serializer.py
+++ b/src/notebook_serializer.py
@@ -4,9 +4,17 @@ import ansi2html
 import sys
 import os
 import json
+import argparse
 
-# Get UNIQUE notebook path with argv and cwd
-
+# main code
+parser = argparse.ArgumentParser()
+parser.add_argument("-n", "--notebook_path", help="Path to the output notebook", default=None, type=str)
+args = parser.parse_args()
+if args.notebook_path:
+    notebook_path = os.path.join(os.getcwd(), args.notebook_path)
+    base, ext = os.path.splitext(notebook_path)
+    if ext.lower() != '.ipynb':
+        notebook_path += '.ipynb'
 
 # Global variable for code cells
 nb = nbf.new_notebook()
@@ -17,8 +25,9 @@ def ansi_to_html(ansi_text):
     return html_text
 
 def write_to_notebook():
-    with open('output_notebook.ipynb', 'w') as f:
-        nbformat.write(nb, f)
+    if args.notebook_path:
+        with open(notebook_path, 'w') as f:
+            nbformat.write(nb, f)
 
 def append_code_cell(code):
     code_cell = nbf.new_code_cell(source=code)

--- a/src/response_parser.py
+++ b/src/response_parser.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functional import *
-
+from notebook_serializer import serialize_conv_into_notebook
 
 class ChoiceStrategy(metaclass=ABCMeta):
     def __init__(self, choice):
@@ -134,10 +134,17 @@ class FinishReasonChoiceStrategy(ChoiceStrategy):
                     content_to_display=content_to_display, history=history, unique_id=bot_backend.unique_id
                 )
 
+                serialize_conv_into_notebook()
+
             except json.JSONDecodeError:
                 history.append(
                     [None, f"GPT generate wrong function args: {bot_backend.function_args_str}"]
                 )
+                whether_exit = True
+                return history, whether_exit
+
+            except KeyError as key_error:
+                history.append([None, f'Backend key_error: {key_error}'])
                 whether_exit = True
                 return history, whether_exit
 

--- a/src/response_parser.py
+++ b/src/response_parser.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functional import *
-from notebook_serializer import serialize_conv_into_notebook
+# from notebook_serializer import serialize_conv_into_notebook
 
 class ChoiceStrategy(metaclass=ABCMeta):
     def __init__(self, choice):
@@ -133,8 +133,6 @@ class FinishReasonChoiceStrategy(ChoiceStrategy):
                 add_function_response_to_bot_history(
                     content_to_display=content_to_display, history=history, unique_id=bot_backend.unique_id
                 )
-
-                serialize_conv_into_notebook()
 
             except json.JSONDecodeError:
                 history.append(

--- a/src/response_parser.py
+++ b/src/response_parser.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 from functional import *
-# from notebook_serializer import serialize_conv_into_notebook
 
 class ChoiceStrategy(metaclass=ABCMeta):
     def __init__(self, choice):

--- a/src/response_parser.py
+++ b/src/response_parser.py
@@ -80,6 +80,7 @@ class ArgumentsFunctionCallChoiceStrategy(ChoiceStrategy):
             solely of raw code text (not a JSON format).
             """
             temp_code_str = bot_backend.function_args_str
+            bot_backend.update_code_str(code_str=temp_code_str)
             bot_backend.update_display_code_block(
                 display_code_block="\n🔴Working:\n```python\n{}\n```".format(temp_code_str)
             )
@@ -87,6 +88,7 @@ class ArgumentsFunctionCallChoiceStrategy(ChoiceStrategy):
             history[-1][1] += bot_backend.display_code_block
         else:
             temp_code_str = parse_json(function_args=bot_backend.function_args_str, finished=False)
+            bot_backend.update_code_str(code_str=temp_code_str)
             if temp_code_str is not None:
                 bot_backend.update_display_code_block(
                     display_code_block="\n🔴Working:\n```python\n{}\n```".format(
@@ -115,6 +117,7 @@ class FinishReasonChoiceStrategy(ChoiceStrategy):
 
                 code_str = self.get_code_str(bot_backend)
 
+                bot_backend.update_code_str(code_str=code_str)
                 bot_backend.update_display_code_block(
                     display_code_block="\n🟢Working:\n```python\n{}\n```".format(code_str)
                 )


### PR DESCRIPTION
# Conversation saving into jupyter notebook
Hello, this is a pull request to  allow the user to save his conversations into jupyter notebooks.  

### Usage:
Add the `--notebook` or `-n` option when running `python3 web_ui.py`:
```shell 
python3 web_ui.py -n path_to_notebook
```
For every new message the notebook will be updated.

### Implementation
I have added a serialization module that uses nbformat package.
The module offers a few functions to serialize code, code outputs/errors, images and usr/assistant messages into the notebook.
The module also uses argparse to allow the user to specify the path to the notebook.
The conversation doesn't get serialized if the notebook option is not used,  
leaving the behavior of `Local-Code-Interpreter`  unchanged if the notebook option is not used.

I am  currently working on notebook deserialization into conversation to allow you pick up where left off.
I wanted to make this PR as soon as the serialization is done so the PR doesn't get to big or out of sync.

I hope this will be useful!

[serialization_demo_gif](https://github.com/MrGreyfun/Local-Code-Interpreter/assets/60320694/e556a375-cec7-42df-ab2b-0414f5e77a40)
